### PR TITLE
add & add_json to return the ID of the posted message

### DIFF
--- a/api.php
+++ b/api.php
@@ -18,6 +18,8 @@ class Api extends CI_Controller {
 		);
 
 		$this->db->insert('whispers', $data);
+		// Return the ID of the newly inserted message
+		echo $this->db->insert_id();
 	}
 
 	public function add_json()

--- a/api.php
+++ b/api.php
@@ -31,10 +31,8 @@ class Api extends CI_Controller {
 		);
 
 		$this->db->insert('whispers', $data);
-
-		// TODO: would be nice if this function returned
-		// the ID of the new message.
-		echo "123";
+		// Return the ID of the newly inserted message
+		echo $this->db->insert_id();
 	}
 	
 	public function get_servertime()


### PR DESCRIPTION
Having the ID of the posted  message can be useful on the client side. For example when posting a message with a delay of 5 minutes. Then on the client side you notify the user that the message is pending. You set a timer to remove the pending notification in 5-6 minutes, unless this message arrives from the server when you do get messages. How do you know this message arrived? I think a good way would be to compare the ID, because comparing text can be misleading.
