### PR TITLE
No output on invalid request

### DIFF
--- a/api.php
+++ b/api.php
@@ -4,7 +4,8 @@ class Api extends CI_Controller {
 
 	public function index()
 	{
-		die('POIS!');
+		// Silence is golden.
+		exit;
 	}
 	
 	public function add()


### PR DESCRIPTION
Silence is golden. Write no output if the request is invalid. It adds no value and writing nothing to the output might give a slight added (but false) feeling of security. If someone stumbles on the page and sees nothing he's probably less likely to start investigating where he's at.

Use exit; insted of die(); as it has less characters and it's [theoretically faster](http://stackoverflow.com/questions/1795025/what-are-the-differences-in-die-and-exit-in-php#answer-13180118).
